### PR TITLE
Update asmdefs settings to support older Unity versions

### DIFF
--- a/Runtime/Unity.st.rect-ex.Runtime.asmdef
+++ b/Runtime/Unity.st.rect-ex.Runtime.asmdef
@@ -1,13 +1,12 @@
 {
     "name": "st.rect-ex.Runtime",
     "references": [],
-    "optionalUnityReferences": [],
     "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": true,
+    "autoReferenced": false,
     "defineConstraints": [],
     "versionDefines": []
 }

--- a/Tests/Editor/Unity.st.rect-ex.Editor.Tests.asmdef
+++ b/Tests/Editor/Unity.st.rect-ex.Editor.Tests.asmdef
@@ -1,7 +1,7 @@
 {
     "name": "st.rect-ex.Editor.Tests",
     "references": [
-        "GUID:73c70a6eb6b6f444c878926f743350f6"
+        "st.rect-ex.Runtime"
     ],
     "optionalUnityReferences": [
         "TestAssemblies"
@@ -11,11 +11,10 @@
     ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
-    "overrideReferences": false,
-    "precompiledReferences": [
-        ""
-    ],
-    "autoReferenced": true,
-    "defineConstraints": [],
-    "versionDefines": []
+    "overrideReferences": true,
+    "precompiledReferences": [],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ]
 }


### PR DESCRIPTION
Fix for https://github.com/slavniyteo/one-line/issues/42

Tested on windows platform.

DOD:
1. start empty app with plugin without errors
2. no changes in *.asmdef after full reimport
3. oneline examples draws
4. editor tests passes for rect-ex

By version:
2017.4.1f1 - passed (manual installation, UPM not supported here) 
2018.2.9f1 - passed (UPM)
2018.3.11f1 - passed (UPM)
2018.4.5f1 - passed (UPM)
2019.2.0f1 - passed (UPM)

UPD:
2018.3.0f2 (Ubuntu) - passed (UPM)